### PR TITLE
From: Christoph Schroeder [mailto:christoph.schroeder@helmholtz-berli…

### DIFF
--- a/ethercatApp/scannerSrc/classes.h
+++ b/ethercatApp/scannerSrc/classes.h
@@ -143,6 +143,7 @@ struct EC_SDO
 };
 typedef  union  {
     char data[4];
+    uint32_t data32;
     uint16_t data16;
     uint8_t data8;
 } sdodata_t;

--- a/ethercatApp/scannerSrc/scanner.c
+++ b/ethercatApp/scannerSrc/scanner.c
@@ -162,6 +162,11 @@ void read_sdo(EC_SDO_ENTRY *sdoentry)
             EC_READ_U16(ecrt_sdo_request_data(sdoentry->sdo_request));
         /* printf("read_sdo 16-bit value = %d\n", sdoentry->sdodata.data16); */
         break;
+    case 32:
+        sdoentry->sdodata.data32 =
+            EC_READ_U32(ecrt_sdo_request_data(sdoentry->sdo_request));
+        /* printf("read_sdo 32-bit value = %d\n", sdoentry->sdodata.data32); */
+        break;
     }
     SDO_READ_MESSAGE *msg = (SDO_READ_MESSAGE *)sdoentry->readmsg;
     msg->value[0] = sdoentry->sdodata.data[0];
@@ -187,6 +192,11 @@ void write_sdo(EC_SDO_ENTRY *sdoentry)
     case 16:
         EC_WRITE_U16(ecrt_sdo_request_data(sdoentry->sdo_request),
                      sdoentry->sdodata.data16);
+        ecrt_sdo_request_write(sdoentry->sdo_request);
+        break;
+    case 32:
+        EC_WRITE_U32(ecrt_sdo_request_data(sdoentry->sdo_request),
+                     sdoentry->sdodata.data32);
         ecrt_sdo_request_write(sdoentry->sdo_request);
         break;
     }

--- a/ethercatApp/scannerSrc/unpack.c
+++ b/ethercatApp/scannerSrc/unpack.c
@@ -167,6 +167,9 @@ int32_t sdocast_int32(EC_SDO_ENTRY *sdoentry,SDO_READ_MESSAGE *msg)
     case 16:
         value = *(uint16_t *)(msg->value);
         break;
+    case 32:
+        value = *(uint32_t *)(msg->value);
+        break;
     }
     return value;
 }


### PR DESCRIPTION
…n.de]

Sent: 27 July 2015 17:08
To: Mercado, Ronaldo (DLSLtd,RAL,TEC)
Subject: Re: DLS EtherCAT Problem with reading SDOs

Hi Ronaldo,

I totally missed out, that there already is a template for SDOs. The main problem was the lack of the "_trig" record, which isn't mentioned in the documentation (http://controls.diamond.ac.uk/downloads/support/ethercat/4-3/documentation/doxygen/sdo_support.html).

I modified the Scanner to allow the reading of 32bit SDOs and couldn't observe the loss of the first 8bits because my values aren't that big, but there is a possible conversion problem since "sdocast_int32" returns a 32bit signed value while the most SDOs are unsigned.

I attached the changes I made to this mail. Thank you for the help.

Best regards,
Christoph
